### PR TITLE
Color Contrast changes

### DIFF
--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -10,7 +10,7 @@ export const getColorsForValues = (
   if (keys.length <= ACCENT_COUNT) {
     return getHashBasedMapping(
       keys,
-      getAccentColors({ light: false, dark: false }, palette),
+      getAccentColors({ light: false, main: false }, palette),
       existingMapping,
       (color: string) => getPreferredColor(color, palette),
     );

--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -12,9 +12,9 @@ export const getAccentColors = (
   palette?: ColorPalette,
 ) => {
   const ranges = [];
+  dark && ranges.push(getDarkAccentColors(palette));
   main && ranges.push(getMainAccentColors(palette));
   light && ranges.push(getLightAccentColors(palette));
-  dark && ranges.push(getDarkAccentColors(palette));
 
   return harmony ? _.unzip(ranges).flat() : ranges.flat();
 };


### PR DESCRIPTION
Changes:
- Charts with default color will be changed to higher contrast
- New Charts will be created by default with Higher contrast
- Charts whose colors are explicitely chosen they will remain unaffected

- Chart with By default color selected will be changed to Higher contrast
![Screenshot from 2023-07-25 22-27-09](https://github.com/dapplooker/analyzer/assets/68886718/eace25b8-67e6-4e50-9fd3-37d8d7a58c8a)

- New Charts will be created by default with Higher contrast
![Screenshot from 2023-07-25 22-30-23](https://github.com/dapplooker/analyzer/assets/68886718/2f77b1c3-edac-460a-8d7e-cd1ffae517b5)

- Charts whose colors are explicitely chosen they will remain unaffected
![Screenshot from 2023-07-25 22-28-44](https://github.com/dapplooker/analyzer/assets/68886718/20b16007-a08a-4556-aedd-bc7817a7033a)


