### PR TITLE
Enable Sharing for users

### DIFF
--- a/frontend/src/metabase/css/core/spacing.css
+++ b/frontend/src/metabase/css/core/spacing.css
@@ -8,6 +8,13 @@
   --margin-2: 1rem;
   --margin-3: 1.5rem;
   --margin-4: 2rem;
+
+  --radius-1: 0.25rem;
+  --radius-2: 0.5rem;
+}
+
+.rounded-sm{
+  border-radius: 6px;
 }
 
 .ml-auto,

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -30,6 +30,7 @@ export const getDashboardActions = (
     onSharingClick,
     onFullscreenChange,
     hasNightModeToggle,
+    user,
   },
 ) => {
   const isPublicLinksEnabled = MetabaseSettings.get("enable-public-sharing");
@@ -48,7 +49,7 @@ export const getDashboardActions = (
   const canShareDashboard = hasCards;
   const canCreateSubscription = hasDataCards && canManageSubscriptions;
 
-  if (!isEditing && !isEmpty && !isPublic) {
+  if (!isEditing && !isEmpty) {
     // Getting notifications with static text-only cards doesn't make a lot of sense
     // if (canCreateSubscription && !isFullscreen) {
     //   buttons.push(
@@ -72,8 +73,11 @@ export const getDashboardActions = (
           enabled={
             !isEditing &&
             !isFullscreen &&
-            ((isPublicLinksEnabled && (isAdmin || dashboard.public_uuid)) ||
+            ((isPublicLinksEnabled && isAdmin) ||
+              (isPublicLinksEnabled && user?.id === dashboard?.creator_id) ||
               (isEmbeddingEnabled && isAdmin))
+            // ((isPublicLinksEnabled && (isAdmin || dashboard.public_uuid)) ||
+            //   (isEmbeddingEnabled && isAdmin))
           }
           isLinkEnabled={canShareDashboard}
           linkText={

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -29,6 +29,7 @@ import {
   addActionToDashboard,
   toggleSidebar,
 } from "metabase/dashboard/actions";
+import { getUser } from "metabase/selectors/user";
 
 import Header from "../components/DashboardHeader";
 import { SIDEBAR_NAME } from "../constants";
@@ -39,6 +40,7 @@ import {
 
 const mapStateToProps = (state, props) => {
   return {
+    user: getUser(state, props),
     isBookmarked: getIsBookmarked(state, props),
     isNavBarOpen: getIsNavbarOpen(state),
     isShowingDashboardInfoSidebar: getIsShowDashboardInfoSidebar(state),

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -99,7 +99,7 @@ class DashboardSharingEmbeddingModal extends Component {
           }}
           // getPublicUrl={({ public_uuid }) => Urls.publicDashboard(public_uuid)}
           getPublicUrl={({ public_uuid }) =>
-            Urls.getDashboardApiEndpoint(public_uuid)
+            Urls.createPublicDiscoverUrlForDashboard(public_uuid)
           }
         />
       </ModalWithTrigger>

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -85,8 +85,8 @@ class DashboardSharingEmbeddingModal extends Component {
           resource={dashboard}
           resourceParameters={parameters}
           resourceType="dashboard"
-          onCreatePublicLink={() => createPublicLink(dashboard)}
-          onDisablePublicLink={() => deletePublicLink(dashboard)}
+          onCreatePublicLink={() => createPublicLink(dashboard)} //backend api call modified
+          onDisablePublicLink={() => deletePublicLink(dashboard)} //backend api call modified
           onUpdateEnableEmbedding={enableEmbedding =>
             updateEnableEmbedding(dashboard, enableEmbedding)
           }

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -97,7 +97,10 @@ class DashboardSharingEmbeddingModal extends Component {
             this._modal && this._modal.close();
             additionalClickActions();
           }}
-          getPublicUrl={({ public_uuid }) => Urls.publicDashboard(public_uuid)}
+          // getPublicUrl={({ public_uuid }) => Urls.publicDashboard(public_uuid)}
+          getPublicUrl={({ public_uuid }) =>
+            Urls.getDashboardApiEndpoint(public_uuid)
+          }
         />
       </ModalWithTrigger>
     );

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -101,6 +101,9 @@ class DashboardSharingEmbeddingModal extends Component {
           getPublicUrl={({ public_uuid }) =>
             Urls.createPublicDiscoverUrlForDashboard(public_uuid)
           }
+          getPublicEmbedUrl={({ public_uuid }) =>
+            Urls.getPublicEmbedUrlForDashboard(public_uuid)
+          }
         />
       </ModalWithTrigger>
     );

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -48,7 +48,7 @@ export function getQuerySearchParams() {
 }
 
 export function createPublicDiscoverUrlForDashboard(uuid: string) {
-  const siteUrl = "http://dlooker.com:8080/dashboard";
+  const siteUrl = "https://dapplooker.com/dashboard";
 
   const endPath = window.location?.pathname.split("/").pop() || "";
 

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -31,7 +31,7 @@ export function publicDashboard(uuid: string) {
   return `${siteUrl}/public/dashboard/${uuid}`;
 }
 
-export function getCurrentQuerySearchParams() {
+export function getQuerySearchParams() {
   const searchParams = new URLSearchParams(window.location.search);
 
   const paramsObject: any = {};
@@ -48,7 +48,7 @@ export function getCurrentQuerySearchParams() {
 }
 
 export function getDashboardApiEndpoint(uuid: string) {
-  const siteUrl = "http://dlooker.com:8080/dashboard";
+  const siteUrl = "https://dapplooker.com";
 
   const endPath = window.location?.pathname.split("/").pop() || "";
 
@@ -56,7 +56,7 @@ export function getDashboardApiEndpoint(uuid: string) {
 
   const formattedEndPath = match ? `${match[2]}-${match[1]}` : endPath;
 
-  const searchParams = getCurrentQuerySearchParams();
+  const searchParams = getQuerySearchParams();
 
   const searchQuery = searchParams ? `?${searchParams}` : "";
 

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -64,7 +64,7 @@ export function createPublicDiscoverUrlForDashboard(uuid: string) {
 }
 
 export function getPublicEmbedUrlForDashboard(uuid: string) {
-  const url = "https://analytics.dapplooker.com/public/dasboard";
+  const url = "https://analytics.dapplooker.com/public/dashboard";
 
   return `${url}/${uuid}`;
 }

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -56,19 +56,17 @@ export function createPublicDiscoverUrlForDashboard(uuid: string) {
 
   const formattedEndPath = match ? `${match[2]}-${match[1]}` : endPath;
 
-  const searchParams = getQuerySearchParams();
+  // const searchParams = getQuerySearchParams();
 
-  const searchQuery = searchParams ? `?${searchParams}` : "";
+  // const searchQuery = searchParams ? `?${searchParams}` : "";
 
-  return `${siteUrl}/${formattedEndPath}` + searchQuery;
+  return `${siteUrl}/${formattedEndPath}`;
 }
 
 export function getPublicEmbedUrlForDashboard(uuid: string) {
   const url = "https://analytics.dapplooker.com/public/dasboard";
 
-  const searchParams = getQuerySearchParams();
-
-  return `${url}/${uuid}${searchParams && `?${searchParams}`}`;
+  return `${url}/${uuid}`;
 }
 
 export function embedDashboard(token: string) {

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -47,8 +47,8 @@ export function getQuerySearchParams() {
   return querySearchParams;
 }
 
-export function getDashboardApiEndpoint(uuid: string) {
-  const siteUrl = "https://dapplooker.com";
+export function createPublicDiscoverUrlForDashboard(uuid: string) {
+  const siteUrl = "http://dlooker.com:8080/dashboard";
 
   const endPath = window.location?.pathname.split("/").pop() || "";
 

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -63,6 +63,14 @@ export function createPublicDiscoverUrlForDashboard(uuid: string) {
   return `${siteUrl}/${formattedEndPath}` + searchQuery;
 }
 
+export function getPublicEmbedUrlForDashboard(uuid: string) {
+  const url = "https://analytics.dapplooker.com/public/dasboard";
+
+  const searchParams = getQuerySearchParams();
+
+  return `${url}/${uuid}${searchParams && `?${searchParams}`}`;
+}
+
 export function embedDashboard(token: string) {
   const siteUrl = MetabaseSettings.get("site-url");
   return `${siteUrl}/embed/dashboard/${token}`;

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -31,6 +31,38 @@ export function publicDashboard(uuid: string) {
   return `${siteUrl}/public/dashboard/${uuid}`;
 }
 
+export function getCurrentQuerySearchParams() {
+  const searchParams = new URLSearchParams(window.location.search);
+
+  const paramsObject: any = {};
+
+  searchParams.forEach((value, key) => {
+    paramsObject[key] = value;
+  });
+
+  const querySearchParams = Object.keys(paramsObject)
+    .map(key => `${key}=${paramsObject[key]}`)
+    .join("&");
+
+  return querySearchParams;
+}
+
+export function getDashboardApiEndpoint(uuid: string) {
+  const siteUrl = "http://dlooker.com:8080/dashboard";
+
+  const endPath = window.location?.pathname.split("/").pop() || "";
+
+  const match = endPath.match(/^(\d+)-(.+)$/);
+
+  const formattedEndPath = match ? `${match[2]}-${match[1]}` : endPath;
+
+  const searchParams = getCurrentQuerySearchParams();
+
+  const searchQuery = searchParams ? `?${searchParams}` : "";
+
+  return `${siteUrl}/${formattedEndPath}` + searchQuery;
+}
+
 export function embedDashboard(token: string) {
   const siteUrl = MetabaseSettings.get("site-url");
   return `${siteUrl}/embed/dashboard/${token}`;

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -154,27 +154,23 @@ export function createPublicDiscoverUrlForChart(
 
   const formattedEndPath = match ? `${match[2]}-${match[1]}` : endPath;
 
-  const searchParams = getCurrentQuerySearchParams();
+  // const searchParams = getCurrentQuerySearchParams();
 
-  const searchQuery = searchParams
-    ? query
-      ? `?${searchParams}&${query}`
-      : `?${searchParams}`
-    : query
-    ? `?${query}`
-    : "";
+  // const searchQuery = searchParams
+  //   ? query
+  //     ? `?${searchParams}&${query}`
+  //     : `?${searchParams}`
+  //   : query
+  //   ? `?${query}`
+  //   : "";
 
-  return (
-    `${siteUrl}/${formattedEndPath}` + (type ? `.${type}` : "") + searchQuery
-  );
+  return `${siteUrl}/${formattedEndPath}` + (type ? `.${type}` : "");
 }
 
 export function getPublicEmbedUrlForChart(uuid: string) {
   const url = "https://analytics.dapplooker.com/public/question";
 
-  const searchParams = getCurrentQuerySearchParams();
-
-  return `${url}/${uuid}${searchParams && `?${searchParams}`}`;
+  return `${url}/${uuid}`;
 }
 
 export function chartApiEndPoint(uuid: string, type: string | null = null) {

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -146,7 +146,7 @@ export function createPublicDiscoverUrlForChart(
   type: string | null = null,
   query?: string,
 ) {
-  const siteUrl = "http://dlooker.com:8080/chart";
+  const siteUrl = "https://dapplooker.com/chart";
 
   const endPath = window.location?.pathname.split("/").pop() || "";
 

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -111,6 +111,22 @@ export function newQuestion({
   }
 }
 
+export function getCurrentQuerySearchParams() {
+  const searchParams = new URLSearchParams(window.location.search);
+
+  const paramsObject: any = {};
+
+  searchParams.forEach((value, key) => {
+    paramsObject[key] = value;
+  });
+
+  const querySearchParams = Object.keys(paramsObject)
+    .map(key => `${key}=${paramsObject[key]}`)
+    .join("&");
+
+  return querySearchParams;
+}
+
 export function publicQuestion(
   uuid: string,
   type: string | null = null,
@@ -125,18 +141,38 @@ export function publicQuestion(
   );
 }
 
-export function chartApiEndPoint(uuid: string, type: string | null = null) {
-  const searchParams = new URLSearchParams(window.location.search);
-  const paramsObject: any = {};
-  searchParams.forEach((value, key) => {
-    paramsObject[key] = value;
-  });
+export function createPublicDiscoverUrl(
+  uuid: string,
+  type: string | null = null,
+  query?: string,
+) {
+  const siteUrl = "http://dlooker.com:8080/chart";
 
+  const endPath = window.location?.pathname.split("/").pop() || "";
+
+  const match = endPath.match(/^(\d+)-(.+)$/);
+
+  const formattedEndPath = match ? `${match[2]}-${match[1]}` : endPath;
+
+  const searchParams = getCurrentQuerySearchParams();
+
+  const searchQuery = searchParams
+    ? query
+      ? `?${searchParams}&${query}`
+      : `?${searchParams}`
+    : query
+    ? `?${query}`
+    : "";
+
+  return (
+    `${siteUrl}/${formattedEndPath}` + (type ? `.${type}` : "") + searchQuery
+  );
+}
+
+export function chartApiEndPoint(uuid: string, type: string | null = null) {
   const siteUrl = "https://api.dapplooker.com/chart";
 
-  const queryString = Object.keys(paramsObject)
-    .map(key => `${key}=${paramsObject[key]}`)
-    .join("&");
+  const queryString = getCurrentQuerySearchParams();
 
   const finalQueryString = queryString
     ? `${queryString}&api_key=<API-KEY>&output_format=${type}`
@@ -146,18 +182,9 @@ export function chartApiEndPoint(uuid: string, type: string | null = null) {
 }
 
 export function getImageApiEndPoint(uuid: string, type: string) {
-  const searchParams = new URLSearchParams(window.location.search);
-  const paramsObject: any = {};
-
-  searchParams.forEach((value, key) => {
-    paramsObject[key] = value;
-  });
-
   const siteUrl = `https://api.dapplooker.com/image`;
 
-  const queryString = Object.keys(paramsObject)
-    .map(key => `${key}=${paramsObject[key]}`)
-    .join("&");
+  const queryString = getCurrentQuerySearchParams();
 
   const finalQueryString = queryString
     ? `${queryString}&apiKey=<API-KEY>&type=${type}`

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -169,6 +169,14 @@ export function createPublicDiscoverUrlForChart(
   );
 }
 
+export function getPublicEmbedUrlForChart(uuid: string) {
+  const url = "https://analytics.dapplooker.com/public/question";
+
+  const searchParams = getCurrentQuerySearchParams();
+
+  return `${url}/${uuid}${searchParams && `?${searchParams}`}`;
+}
+
 export function chartApiEndPoint(uuid: string, type: string | null = null) {
   const siteUrl = "https://api.dapplooker.com/chart";
 

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -141,12 +141,12 @@ export function publicQuestion(
   );
 }
 
-export function createPublicDiscoverUrl(
+export function createPublicDiscoverUrlForChart(
   uuid: string,
   type: string | null = null,
   query?: string,
 ) {
-  const siteUrl = "https://dapplooker.com";
+  const siteUrl = "http://dlooker.com:8080/chart";
 
   const endPath = window.location?.pathname.split("/").pop() || "";
 

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -146,7 +146,7 @@ export function createPublicDiscoverUrl(
   type: string | null = null,
   query?: string,
 ) {
-  const siteUrl = "http://dlooker.com:8080/chart";
+  const siteUrl = "https://dapplooker.com";
 
   const endPath = window.location?.pathname.split("/").pop() || "";
 

--- a/frontend/src/metabase/nav/components/AppBar/DappLookerHeaderLinks.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/DappLookerHeaderLinks.tsx
@@ -31,9 +31,8 @@ const NewBadgeImg = styled.img`
 `;
 
 const DappLookerHeaderLinks = (): JSX.Element => {
-  const DAPPLOOKER_MYCREATION_LINK =
-    "https://dapplooker.com/my-creation/dashboard";
-  const DAPPLOOKER_MYPROJECT_LINK = "https://dapplooker.com/user/dashboard";
+  const DAPPLOOKER_ControlCenter_LINK =
+    "https://dapplooker.com/control-center?type=my-projects";
   const ANALYZER_BROWSE_DATA_LINK = "https://analytics.dapplooker.com/browse/2";
 
   const MYCREATION_NEW_BADGE_EXPIRY_DATE = new Date("2023-11-12");
@@ -74,21 +73,13 @@ const DappLookerHeaderLinks = (): JSX.Element => {
         onMouseLeave={resetTextColor}
         style={anchorTagStyle}>Discover</a> */}
       <LinkElement
-        href={DAPPLOOKER_MYPROJECT_LINK}
-        onMouseEnter={changeTextColorOnHover}
-        onMouseLeave={resetTextColor}
-        style={anchorTagStyle}
-      >
-        My Dashboard
-      </LinkElement>
-      <LinkElement
-        href={DAPPLOOKER_MYCREATION_LINK}
+        href={DAPPLOOKER_ControlCenter_LINK}
         onMouseEnter={changeTextColorOnHover}
         onMouseLeave={resetTextColor}
         style={anchorTagStyle}
         isNew={isNewBadgeActive}
       >
-        My Creation
+        Control Center
         {isNewBadgeActive && (
           <NewBadgeImg
             style={newBadgeStyle}

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
@@ -180,7 +180,7 @@ class EmbedModalContent extends Component {
                   )}
                   onChangeEmbedType={embedType => this.setState({ embedType })}
                 />
-              ) :
+              ) : (
                 <DappLookerChartAPIPane
                   {...this.props}
                   publicUrl={getUnsignedPreviewUrl(
@@ -197,7 +197,7 @@ class EmbedModalContent extends Component {
                   )}
                   onChangeEmbedType={embedType => this.setState({ embedType })}
                 />
-              }
+              )}
             </div>
           </div>
         ) : embedType === "application" ? (
@@ -272,11 +272,13 @@ function filterValidResourceParameters(embeddingParams, resourceParameters) {
   return _.pick(embeddingParams, validParameters);
 }
 
-export const EmbedTitle = ({ type, onClick,isChartAPI }) => (
+export const EmbedTitle = ({ type, onClick, isChartAPI }) => (
   <a className="flex align-center" onClick={onClick}>
-    {!isChartAPI
-      ? <span className="text-brand-hover">{t`Sharing`}</span>
-      : <span className="text-brand-hover">{t`Chart API`}</span>}
+    {!isChartAPI ? (
+      <span className="text-brand-hover">{t`Sharing`}</span>
+    ) : (
+      <span className="text-brand-hover">{t`Chart API`}</span>
+    )}
     {type && <Icon name="chevronright" className="mx1 text-medium" />}
     {type}
   </a>

--- a/frontend/src/metabase/public/components/widgets/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane.tsx
@@ -66,7 +66,8 @@ export default function SharingPane({
 
   return (
     <div className="pt2 ml-auto mr-auto" style={{ maxWidth: 600 }}>
-      {isAdmin && isPublicSharingEnabled && (
+      {/* {isAdmin && isPublicSharingEnabled && ( */}
+      {isPublicSharingEnabled && (
         <div className="px4 py3 mb4 bordered rounded flex align-center">
           <Header>{t`Enable sharing`}</Header>
           <div className="ml-auto">
@@ -89,6 +90,7 @@ export default function SharingPane({
               <Toggle
                 value={false}
                 onChange={() => {
+                  console.log("toggle");
                   MetabaseAnalytics.trackStructEvent(
                     "Sharing Modal",
                     "Public Link Enabled",
@@ -150,27 +152,29 @@ export default function SharingPane({
         <CopyWidget value={iframeSource} />
       </SharingOption>
 
-      {isAdmin && <SharingOption
-        className={cx({
-          disabled: shouldDisableEmbedding,
-          "cursor-pointer": !shouldDisableEmbedding,
-        })}
-        illustration={
-          <ResponsiveImage imageUrl="app/assets/img/secure_embed.png" />
-        }
-        onClick={() => {
-          if (!shouldDisableEmbedding) {
-            onChangeEmbedType("application");
+      {/* {isAdmin && (
+        <SharingOption
+          className={cx({
+            disabled: shouldDisableEmbedding,
+            "cursor-pointer": !shouldDisableEmbedding,
+          })}
+          illustration={
+            <ResponsiveImage imageUrl="app/assets/img/secure_embed.png" />
           }
-        }}
-      >
-        <EmbedWidgetHeader>{t`Embed in your application`}</EmbedWidgetHeader>
-        <Description>{t`Add this ${resourceType} to your application server code. You’ll be able to preview the way it looks and behaves before making it securely visible for your users.`}</Description>
-        {embeddingHelperText && (
-          <Description enableMouseEvents>{embeddingHelperText}</Description>
-        )}
-        <Button primary>{t`Set up`}</Button>
-      </SharingOption>}
+          onClick={() => {
+            if (!shouldDisableEmbedding) {
+              onChangeEmbedType("application");
+            }
+          }}
+        >
+          <EmbedWidgetHeader>{t`Embed in your application`}</EmbedWidgetHeader>
+          <Description>{t`Add this ${resourceType} to your application server code. You’ll be able to preview the way it looks and behaves before making it securely visible for your users.`}</Description>
+          {embeddingHelperText && (
+            <Description enableMouseEvents>{embeddingHelperText}</Description>
+          )}
+          <Button primary>{t`Set up`}</Button>
+        </SharingOption>
+      )} */}
     </div>
   );
 }

--- a/frontend/src/metabase/public/components/widgets/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane.tsx
@@ -66,7 +66,6 @@ export default function SharingPane({
 
   const publicLink = getPublicUrl(resource, extensionState);
   const iframeSource = getPublicEmbedHTML(getPublicEmbedUrl(resource));
-  console.log(resource);
 
   useEffect(() => {
     if (toggleState.off && resource.public_uuid) {

--- a/frontend/src/metabase/public/components/widgets/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane.tsx
@@ -84,14 +84,11 @@ export default function SharingPane({
       entityId: resource.id,
     };
     try {
-      await fetch(
-        `http://dlooker.com:8080/web/discover/${action}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        },
-      );
+      await fetch(`https://dapplooker.com/web/discover/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
     }
     catch (e) {
       console.log("Error", e);

--- a/frontend/src/metabase/public/components/widgets/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane.tsx
@@ -22,7 +22,7 @@ import {
 type Resource = {
   dashboard?: number;
   question?: number;
-  public_uuid?: string;
+  public_uuid?: string | null;
   id?: number;
 };
 
@@ -35,6 +35,7 @@ interface SharingPaneProps {
   onDisablePublicLink: () => void;
   extensions: string[];
   getPublicUrl: (resource: Resource, extension?: Extension) => void;
+  getPublicEmbedUrl: (resource: Resource) => void;
   onChangeEmbedType: (embedType: string) => void;
   isAdmin: boolean;
   isPublicSharingEnabled: boolean;
@@ -48,6 +49,7 @@ export default function SharingPane({
   onDisablePublicLink,
   extensions = [],
   getPublicUrl,
+  getPublicEmbedUrl,
   onChangeEmbedType,
   isAdmin,
   isPublicSharingEnabled,
@@ -55,14 +57,16 @@ export default function SharingPane({
 }: SharingPaneProps) {
   const [extensionState, setExtension] = useState<Extension>(null);
 
-  const [toggleState, setToggleState] = useState<{ off: boolean; on: boolean; }>(
+  const [toggleState, setToggleState] = useState<{ off: boolean; on: boolean }>(
     {
       off: false,
       on: false,
-    });
+    },
+  );
 
   const publicLink = getPublicUrl(resource, extensionState);
-  const iframeSource = getPublicEmbedHTML(getPublicUrl(resource));
+  const iframeSource = getPublicEmbedHTML(getPublicEmbedUrl(resource));
+  console.log(resource);
 
   useEffect(() => {
     if (toggleState.off && resource.public_uuid) {
@@ -74,8 +78,7 @@ export default function SharingPane({
       setToggleState(prev => ({ ...prev, on: false }));
     }
   }, [resource.public_uuid, toggleState]);
-  
-  
+
   const publishOrUnpublishChartDashboard = async (
     action: "publish" | "unpublish",
   ) => {
@@ -89,8 +92,7 @@ export default function SharingPane({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-    }
-    catch (e) {
+    } catch (e) {
       console.log("Error", e);
     }
   };
@@ -156,7 +158,7 @@ export default function SharingPane({
         <PublicLinkHeader>{t`Public link`}</PublicLinkHeader>
         <Description className="mb1">{t`Share this ${resourceType} with people who don't have a DappLooker account using the URL below:`}</Description>
         <CopyWidget value={publicLink} />
-        {extensions && extensions.length > 0 && (
+        {/* {extensions && extensions.length > 0 && (
           <div className="mt1">
             {extensions.map(extension => (
               <span
@@ -175,7 +177,7 @@ export default function SharingPane({
               </span>
             ))}
           </div>
-        )}
+        )} */}
       </SharingOption>
 
       <SharingOption

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -11,9 +11,9 @@ import Icon from "metabase/components/Icon";
 import ButtonBar from "metabase/components/ButtonBar";
 
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
-import QuestionEmbedWidget, {
-  QuestionEmbedWidgetTrigger,
-} from "metabase/query_builder/containers/QuestionEmbedWidget";
+// import QuestionEmbedWidget, {
+//   QuestionEmbedWidgetTrigger,
+// } from "metabase/query_builder/containers/QuestionEmbedWidget";
 import { getIconForVisualizationType } from "metabase/visualizations";
 import ViewButton from "./ViewButton";
 
@@ -171,16 +171,16 @@ const ViewFooter = ({
               }
             />
           ),
-          QuestionEmbedWidget.shouldRender({ question, isAdmin }) && (
-            <QuestionEmbedWidgetTrigger
-              key="embeds"
-              onClick={() =>
-                question.isSaved()
-                  ? onOpenModal("embed")
-                  : onOpenModal("save-question-before-embed")
-              }
-            />
-          ),
+          // QuestionEmbedWidget.shouldRender({ question, isAdmin }) && (
+          //   <QuestionEmbedWidgetTrigger
+          //     key="embeds"
+          //     onClick={() =>
+          //       question.isSaved()
+          //         ? onOpenModal("embed")
+          //         : onOpenModal("save-question-before-embed")
+          //     }
+          //   />
+          // ),
           // QuestionTimelineWidget.shouldRender({ isTimeseries }) && (
           //   <QuestionTimelineWidget
           //     key="timelines"

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -16,9 +16,11 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import SavedQuestionHeaderButton from "metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton";
 
-import { QuestionAPIWidgetTrigger } from "metabase/query_builder/containers/QuestionEmbedWidget";
+import {
+  QuestionEmbedWidgetTrigger,
+  QuestionAPIWidgetTrigger,
+} from "metabase/query_builder/containers/QuestionEmbedWidget";
 import RunButtonWithTooltip from "../RunButtonWithTooltip";
-
 import QuestionActions from "../QuestionActions";
 import QueryDownloadWidget from "../QueryDownloadWidget";
 import { HeadBreadcrumbs } from "./HeaderBreadcrumbs";
@@ -350,6 +352,8 @@ ViewTitleHeaderRightSide.propTypes = {
   isShowingQuestionInfoSidebar: PropTypes.bool,
   onModelPersistenceChange: PropTypes.bool,
   onQueryChange: PropTypes.func,
+  isAdmin: PropTypes.bool,
+  user: PropTypes.object,
 };
 
 function ViewTitleHeaderRightSide(props) {
@@ -384,6 +388,8 @@ function ViewTitleHeaderRightSide(props) {
     onOpenQuestionInfo,
     onModelPersistenceChange,
     onQueryChange,
+    isAdmin,
+    user,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
   const query = question.query();
@@ -462,6 +468,17 @@ function ViewTitleHeaderRightSide(props) {
           card={question.card()}
           result={result}
           bordered={true}
+        />
+      )}
+
+      {isSaved && (isAdmin || user?.id === question._card?.creator_id) && (
+        <QuestionEmbedWidgetTrigger
+          key="embeds"
+          onClick={() =>
+            question.isSaved()
+              ? onOpenModal("embed")
+              : onOpenModal("save-question-before-embed")
+          }
         />
       )}
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -472,14 +472,14 @@ function ViewTitleHeaderRightSide(props) {
       )}
 
       {isSaved && (isAdmin || user?.id === question._card?.creator_id) && (
-        <QuestionEmbedWidgetTrigger
-          key="embeds"
-          onClick={() =>
-            question.isSaved()
-              ? onOpenModal("embed")
-              : onOpenModal("save-question-before-embed")
-          }
-        />
+          <QuestionEmbedWidgetTrigger
+            key="embeds"
+            onClick={() =>
+              question.isSaved()
+                ? onOpenModal("embed")
+                : onOpenModal("save-question-before-embed")
+            }
+          />
       )}
 
       {QuestionNotebookButton.shouldRender(props) && (

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -81,9 +81,8 @@ class QuestionEmbedWidget extends Component {
         resourceType="question"
         resourceParameters={getCardUiParameters(card, metadata)}
         onGetChartApi={() => getChartAPI(card)}
-        onCreatePublicLink={() => getChartAPI(card)}
-        // onCreatePublicLink={() => createPublicLink(card)}
-        onDisablePublicLink={() => deletePublicLink(card)} //api call modified
+        onCreatePublicLink={() => createPublicLink(card)} //backend api call modified
+        onDisablePublicLink={() => deletePublicLink(card)} //backend api call modified
         onUpdateEnableEmbedding={enableEmbedding =>
           updateEnableEmbedding(card, enableEmbedding)
         }

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -72,6 +72,7 @@ class QuestionEmbedWidget extends Component {
       metadata,
       ...props
     } = this.props;
+
     return (
       <EmbedModalContent
         {...props}
@@ -80,16 +81,20 @@ class QuestionEmbedWidget extends Component {
         resourceType="question"
         resourceParameters={getCardUiParameters(card, metadata)}
         onGetChartApi={() => getChartAPI(card)}
-        onCreatePublicLink={() => createPublicLink(card)}
-        onDisablePublicLink={() => deletePublicLink(card)}
+        onCreatePublicLink={() => getChartAPI(card)}
+        // onCreatePublicLink={() => createPublicLink(card)}
+        onDisablePublicLink={() => deletePublicLink(card)} //api call modified
         onUpdateEnableEmbedding={enableEmbedding =>
           updateEnableEmbedding(card, enableEmbedding)
         }
         onUpdateEmbeddingParams={embeddingParams =>
           updateEmbeddingParams(card, embeddingParams)
         }
+        // getPublicUrl={({ public_uuid }, extension) =>
+        //   Urls.publicQuestion(public_uuid, extension)
+        // }
         getPublicUrl={({ public_uuid }, extension) =>
-          Urls.publicQuestion(public_uuid, extension)
+          Urls.createPublicDiscoverUrl(public_uuid, extension)
         }
         getChartApiEndPoint={({ public_uuid }, extension) =>
           Urls.chartApiEndPoint(public_uuid, extension)
@@ -138,6 +143,7 @@ export function QuestionEmbedWidgetTrigger({ onClick }) {
         );
         onClick();
       }}
+      data-metabase-event="View Mode; Open Filter Modal"
     />
   );
 }

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -95,6 +95,9 @@ class QuestionEmbedWidget extends Component {
         getPublicUrl={({ public_uuid }, extension) =>
           Urls.createPublicDiscoverUrlForChart(public_uuid, extension)
         }
+        getPublicEmbedUrl={({ public_uuid }) =>
+          Urls.getPublicEmbedUrlForChart(public_uuid)
+        }
         getChartApiEndPoint={({ public_uuid }, extension) =>
           Urls.chartApiEndPoint(public_uuid, extension)
         }

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -5,7 +5,8 @@ import { connect } from "react-redux";
 
 import { t } from "ttag";
 
-import Icon from "metabase/components/Icon";
+import Tooltip from "metabase/core/components/Tooltip";
+import Button from "metabase/core/components/Button";
 
 import EmbedModalContent from "metabase/public/components/widgets/EmbedModalContent";
 
@@ -16,7 +17,10 @@ import { getMetadata } from "metabase/selectors/metadata";
 import { color } from "metabase/lib/colors";
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 
-import { HeaderButton } from "../components/view/ViewHeader.styled";
+import {
+  HeaderButton,
+  ViewHeaderIconButtonContainer,
+} from "../components/view/ViewHeader.styled";
 
 import {
   createPublicLink,
@@ -133,20 +137,25 @@ export default connect(
 
 export function QuestionEmbedWidgetTrigger({ onClick }) {
   return (
-    <Icon
-      name="share"
-      tooltip={t`Sharing`}
-      className="px1 py1 hide sm-show text-brand-hover cursor-pointer bg-medium-hover rounded-sm transition-background"
-      onClick={() => {
-        MetabaseAnalytics.trackStructEvent(
-          "Sharing / Embedding",
-          "question",
-          "Sharing Link Clicked",
-        );
-        onClick();
-      }}
-      data-metabase-event="View Mode; Open Filter Modal"
-    />
+    <ViewHeaderIconButtonContainer>
+      <Tooltip tooltip={t`Sharing`}>
+        <Button
+          borderless
+          iconSize={16}
+          medium
+          className="text-dark text-brand-hover"
+          icon="share"
+          onClick={() => {
+            MetabaseAnalytics.trackStructEvent(
+              "Sharing / Embedding",
+              "question",
+              "Sharing Link Clicked",
+            );
+            onClick();
+          }}
+        />
+      </Tooltip>
+    </ViewHeaderIconButtonContainer>
   );
 }
 

--- a/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
+++ b/frontend/src/metabase/query_builder/containers/QuestionEmbedWidget.jsx
@@ -93,7 +93,7 @@ class QuestionEmbedWidget extends Component {
         //   Urls.publicQuestion(public_uuid, extension)
         // }
         getPublicUrl={({ public_uuid }, extension) =>
-          Urls.createPublicDiscoverUrl(public_uuid, extension)
+          Urls.createPublicDiscoverUrlForChart(public_uuid, extension)
         }
         getChartApiEndPoint={({ public_uuid }, extension) =>
           Urls.chartApiEndPoint(public_uuid, extension)
@@ -133,7 +133,7 @@ export function QuestionEmbedWidgetTrigger({ onClick }) {
     <Icon
       name="share"
       tooltip={t`Sharing`}
-      className="mx1 hide sm-show text-brand-hover cursor-pointer"
+      className="px1 py1 hide sm-show text-brand-hover cursor-pointer bg-medium-hover rounded-sm transition-background"
       onClick={() => {
         MetabaseAnalytics.trackStructEvent(
           "Sharing / Embedding",

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1035,7 +1035,7 @@ saved later when it is ready."
 (api/defendpoint-schema DELETE "/:card-id/public_link"
   "Delete the publicly-accessible link to this Card."
   [card-id]
-  (validation/check-has-application-permission :setting)
+  ;; (validation/check-has-application-permission :setting) //disable validation
   (validation/check-public-sharing-enabled)
   (api/check-exists? Card :id card-id, :public_uuid [:not= nil])
   (db/update! Card card-id

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -998,21 +998,51 @@ saved later when it is ready."
 
 ;;; ----------------------------------------------- Sharing is Caring ------------------------------------------------
 
+;; #_{:clj-kondo/ignore [:deprecated-var]}
+;; (api/defendpoint-schema POST "/:card-id/public_link"
+;;   "Generate publicly-accessible links for this Card. Returns UUID to be used in public links. (If this Card has
+;;   already been shared, it will return the existing public link rather than creating a new one.)  Public sharing must
+;;   be enabled."
+;;   [card-id]
+;;   (validation/check-has-application-permission :setting)
+;;   (validation/check-public-sharing-enabled)
+;;   (api/check-not-archived (api/read-check Card card-id))
+;;   (let [{existing-public-uuid :public_uuid} (db/select-one [Card :public_uuid] :id card-id)]
+;;     {:uuid (or existing-public-uuid
+;;                (u/prog1 (str (UUID/randomUUID))
+;;                  (db/update! Card card-id
+;;                    :public_uuid       <>
+;;                    :made_public_by_id api/*current-user-id*)))}))
+
+
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/:card-id/public_link"
   "Generate publicly-accessible links for this Card. Returns UUID to be used in public links. (If this Card has
   already been shared, it will return the existing public link rather than creating a new one.)  Public sharing must
   be enabled."
   [card-id]
-  (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check Card card-id))
-  (let [{existing-public-uuid :public_uuid} (db/select-one [Card :public_uuid] :id card-id)]
-    {:uuid (or existing-public-uuid
-               (u/prog1 (str (UUID/randomUUID))
-                 (db/update! Card card-id
-                   :public_uuid       <>
-                   :made_public_by_id api/*current-user-id*)))}))
+  
+  ;; Fetch the card details to get the creator ID
+  (let [card (db/select-one 'Card :id card-id)
+        creator-id (:creator_id card)]
+    
+    ;; Check if the current user is either the creator or has necessary permissions
+    (api/check-403 (or (= api/*current-user-id* creator-id)
+                       (try
+                         (validation/check-has-application-permission :setting)
+                         true
+                         (catch Exception _ false))))
+    
+    ;; Proceed if the current user is the creator or has necessary permissions
+    (let [{existing-public-uuid :public_uuid} (db/select-one [Card :public_uuid] :id card-id)]
+      {:uuid (or existing-public-uuid
+                 (u/prog1 (str (UUID/randomUUID))
+                   (db/update! Card card-id
+                     :public_uuid       <>
+                     :made_public_by_id api/*current-user-id*)))})))
+
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/:card-id/dl_public_link"
@@ -1031,17 +1061,43 @@ saved later when it is ready."
                    :made_public_by_id api/*current-user-id*)))}))
 
 
+;; #_{:clj-kondo/ignore [:deprecated-var]}
+;; (api/defendpoint-schema DELETE "/:card-id/public_link"
+;;   "Delete the publicly-accessible link to this Card."
+;;   [card-id]
+;;   (validation/check-has-application-permission :setting)
+;;   (validation/check-public-sharing-enabled)
+;;   (api/check-exists? Card :id card-id, :public_uuid [:not= nil])
+;;   (db/update! Card card-id
+;;     :public_uuid       nil
+;;     :made_public_by_id nil)
+;;   {:status 204, :body nil})
+
+
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema DELETE "/:card-id/public_link"
   "Delete the publicly-accessible link to this Card."
   [card-id]
-  ;; (validation/check-has-application-permission :setting) //disable validation
   (validation/check-public-sharing-enabled)
   (api/check-exists? Card :id card-id, :public_uuid [:not= nil])
-  (db/update! Card card-id
-    :public_uuid       nil
-    :made_public_by_id nil)
-  {:status 204, :body nil})
+  
+  ;; Fetch the card details to get the creator ID
+  (let [card (db/select-one 'Card :id card-id)
+        creator-id (:creator_id card)]
+    
+    ;; Check if the current user is either the creator or has necessary permissions
+    (api/check-403 (or (= api/*current-user-id* creator-id)
+                       (try
+                         (validation/check-has-application-permission :setting)
+                         true
+                         (catch Exception _ false))))
+    
+    ;; Proceed to delete the public link if the user is authorized
+    (db/update! Card card-id
+      :public_uuid       nil
+      :made_public_by_id nil)
+    {:status 204, :body nil}))
+
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/public"

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -638,7 +638,7 @@
   Dashboard has already been shared, it will return the existing public link rather than creating a new one.) Public
   sharing must be enabled."
   [dashboard-id]
-  (api/check-superuser)
+  ;; (api/check-superuser)
   (validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check Dashboard dashboard-id))
   {:uuid (or (db/select-one-field :public_uuid Dashboard :id dashboard-id)
@@ -651,7 +651,7 @@
 (api/defendpoint-schema DELETE "/:dashboard-id/public_link"
   "Delete the publicly-accessible link to this Dashboard."
   [dashboard-id]
-  (validation/check-has-application-permission :setting)
+  ;; (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
   (api/check-exists? Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
   (db/update! Dashboard dashboard-id

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -632,32 +632,88 @@
 
 ;;; ----------------------------------------------- Sharing is Caring ------------------------------------------------
 
+;; #_{:clj-kondo/ignore [:deprecated-var]}
+;; (api/defendpoint-schema POST "/:dashboard-id/public_link"
+;;   "Generate publicly-accessible links for this Dashboard. Returns UUID to be used in public links. (If this
+;;   Dashboard has already been shared, it will return the existing public link rather than creating a new one.) Public
+;;   sharing must be enabled."
+;;   [dashboard-id]
+;;   (api/check-superuser)
+;;   (validation/check-public-sharing-enabled)
+;;   (api/check-not-archived (api/read-check Dashboard dashboard-id))
+;;   {:uuid (or (db/select-one-field :public_uuid Dashboard :id dashboard-id)
+;;              (u/prog1 (str (UUID/randomUUID))
+;;                (db/update! Dashboard dashboard-id
+;;                  :public_uuid       <>
+;;                  :made_public_by_id api/*current-user-id*)))})
+
+
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/:dashboard-id/public_link"
   "Generate publicly-accessible links for this Dashboard. Returns UUID to be used in public links. (If this
   Dashboard has already been shared, it will return the existing public link rather than creating a new one.) Public
   sharing must be enabled."
   [dashboard-id]
-  ;; (api/check-superuser)
   (validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check Dashboard dashboard-id))
-  {:uuid (or (db/select-one-field :public_uuid Dashboard :id dashboard-id)
-             (u/prog1 (str (UUID/randomUUID))
-               (db/update! Dashboard dashboard-id
-                 :public_uuid       <>
-                 :made_public_by_id api/*current-user-id*)))})
+  
+  ;; Fetch the dashboard details to get the creator ID
+  (let [dashboard (db/select-one 'Dashboard :id dashboard-id)
+        creator-id (:creator_id dashboard)]
+    
+    ;; Check if the current user ID matches the creator ID or if the user is a superuser
+    (api/check-403 (or (= api/*current-user-id* creator-id)
+                   (try
+                     (api/check-superuser)
+                     true
+                     (catch Exception _ false))))
+    
+    ;; Proceed if the current user is the creator or a superuser
+    {:uuid (or (db/select-one-field :public_uuid Dashboard :id dashboard-id)
+               (u/prog1 (str (UUID/randomUUID))
+                 (db/update! Dashboard dashboard-id
+                   :public_uuid       <>
+                   :made_public_by_id api/*current-user-id*)))}))
+
+;; #_{:clj-kondo/ignore [:deprecated-var]}
+;; (api/defendpoint-schema DELETE "/:dashboard-id/public_link"
+;;   "Delete the publicly-accessible link to this Dashboard."
+;;   [dashboard-id]
+;;   (validation/check-has-application-permission :setting)
+;;   (validation/check-public-sharing-enabled)
+;;   (api/check-exists? Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
+;;   (db/update! Dashboard dashboard-id
+;;     :public_uuid       nil
+;;     :made_public_by_id nil)
+;;   {:status 204, :body nil})
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema DELETE "/:dashboard-id/public_link"
   "Delete the publicly-accessible link to this Dashboard."
   [dashboard-id]
-  ;; (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
+  
+  ;; Check if the dashboard exists, has a public UUID, and is not archived
   (api/check-exists? Dashboard :id dashboard-id, :public_uuid [:not= nil], :archived false)
-  (db/update! Dashboard dashboard-id
-    :public_uuid       nil
-    :made_public_by_id nil)
-  {:status 204, :body nil})
+  
+  ;; Fetch the dashboard details to get the creator ID
+  (let [dashboard (db/select-one 'Dashboard :id dashboard-id)
+        creator-id (:creator_id dashboard)]
+    
+    ;; Check if the current user is either the creator or has necessary permissions
+    (api/check-403 (or (= api/*current-user-id* creator-id)
+                      (try
+                        (validation/check-has-application-permission :setting)
+                        true
+                        (catch Exception _ false))))
+    
+    ;; Proceed if the current user is the creator or has necessary permissions
+    (db/update! Dashboard dashboard-id
+      :public_uuid       nil
+      :made_public_by_id nil)
+    {:status 204, :body nil}))
+
+
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/public"

--- a/src/metabase/models/login_history.clj
+++ b/src/metabase/models/login_history.clj
@@ -77,14 +77,15 @@
              (not (first-login-ever? login-history)))
     ;; if there's an existing open connection (and there seems to be one, but I'm not 100% sure why) we can't try to use
     ;; it across threads since it can close at any moment! So unbind it so the future can get its own thread.
-    (binding [t2.conn/*current-connectable* nil]
-      (future
-        ;; off thread for both IP lookup and email sending. Either one could block and slow down user login (#16169)
-        (try
-          (let [[info] (human-friendly-infos [login-history])]
-            (messages/send-login-from-new-device-email! info))
-          (catch Throwable e
-            (log/error e (trs "Error sending ''login from new device'' notification email"))))))))
+    ;; (binding [t2.conn/*current-connectable* nil]
+    ;;   (future
+    ;;     ;; off thread for both IP lookup and email sending. Either one could block and slow down user login (#16169)
+    ;;     (try
+    ;;       (let [[info] (human-friendly-infos [login-history])]
+    ;;         (messages/send-login-from-new-device-email! info))
+    ;;       (catch Throwable e
+    ;;         (log/error e (trs "Error sending ''login from new device'' notification email"))))))
+  ))
 
 (defn- post-insert [login-history]
   (maybe-send-login-from-new-device-email login-history)

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -323,7 +323,8 @@
   [new-user :- NewUser, invitor :- Invitor, setup? :- schema/Bool]
   ;; create the new user
   (u/prog1 (insert-new-user! new-user)
-    (send-welcome-email! <> invitor setup?)))
+    ;; (send-welcome-email! <> invitor setup?)
+  ))
 
 (schema/defn create-new-google-auth-user!
   "Convenience for creating a new user via Google Auth. This account is considered active immediately; thus all active
@@ -331,8 +332,9 @@
   [new-user :- NewUser]
   (u/prog1 (insert-new-user! (assoc new-user :google_auth true))
     ;; send an email to everyone including the site admin if that's set
-    (classloader/require 'metabase.email.messages)
-    ((resolve 'metabase.email.messages/send-user-joined-admin-notification-email!) <>, :google-auth? true)))
+    ;; (classloader/require 'metabase.email.messages)
+    ;; ((resolve 'metabase.email.messages/send-user-joined-admin-notification-email!) <>, :google-auth? true)
+  ))
 
 (schema/defn create-new-ldap-auth-user!
   "Convenience for creating a new user via LDAP. This account is considered active immediately; thus all active admins

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -142,7 +142,7 @@
   (case (keyword condition-type)
     :meets (trs "reached its goal")
     :below (trs "gone below its goal")
-    :rows  (trs "results")))
+    :rows  (trs "Results")))
 
 (def ^:private block-text-length-limit 3000)
 (def ^:private attachment-text-length-limit 2000)
@@ -354,7 +354,7 @@
   [{:keys [id] :as pulse} results channel]
   (log/debug (trs "Sending Alert ({0}: {1}) via email" id name))
   (let [condition-kwd    (messages/pulse->alert-condition-kwd pulse)
-        email-subject    (trs "{0} has {1}"
+        email-subject    (trs "Alert: {0} has {1}"
                               (first-question-name pulse)
                               (alert-condition-type->description condition-kwd))
         email-recipients (filterv u/email? (map :email (:recipients channel)))

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -354,7 +354,7 @@
   [{:keys [id] :as pulse} results channel]
   (log/debug (trs "Sending Alert ({0}: {1}) via email" id name))
   (let [condition-kwd    (messages/pulse->alert-condition-kwd pulse)
-        email-subject    (trs "DappLooker alert: {0} has {1}"
+        email-subject    (trs "{0} has {1}"
                               (first-question-name pulse)
                               (alert-condition-type->description condition-kwd))
         email-recipients (filterv u/email? (map :email (:recipients channel)))

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -49,7 +49,7 @@
 
 (def restful-api-endpoint-prod "https://dapplooker.com")
 
-(def restful-api-endpoint-localhost "http://localhost:4001")
+(def restful-api-endpoint-localhost "http://dlooker.com:8080")
 
 (defn- content-security-policy-header
   "`Content-Security-Policy` header. See https://content-security-policy.com for more details."


### PR DESCRIPTION
- Users can now make their own chart/dashboard public/private.
- On login of any user disable the login notification.
- Modifies the Alert Email Subject.
- Remove extension types from public links.
- Update public embedding URL.

![Screenshot from 2024-07-12 16-11-07](https://github.com/user-attachments/assets/2fe63d63-14a6-4da9-9755-135e37e5a4f8)
![Screenshot from 2024-08-02 14-10-57](https://github.com/user-attachments/assets/d7e4539c-de4c-4e3a-965c-7f8872aaa148)

